### PR TITLE
serverless-jenkins-demo to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.85
 - name: serverless-jenkins-demo
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.9


### PR DESCRIPTION
Promote serverless-jenkins-demo to version 0.0.9